### PR TITLE
Submit Hanlder types and FormValues extraction types

### DIFF
--- a/packages/qwik/src/components/Form.tsx
+++ b/packages/qwik/src/components/Form.tsx
@@ -1,4 +1,4 @@
-import type { QwikSubmitEvent, QwikJSX, PropFunction } from '@builder.io/qwik';
+import type { QwikSubmitEvent, QwikJSX } from '@builder.io/qwik';
 import type { ActionStore } from '@builder.io/qwik-city';
 import type { JSX } from '@builder.io/qwik/jsx-runtime';
 import { getValues, validate } from '../methods';
@@ -7,17 +7,8 @@ import type {
   FieldValues,
   FieldPath,
   FieldArrayPath,
+  SubmitHandler,
 } from '../types';
-
-export type FormSubmitHandler<TFieldValues extends FieldValues> = PropFunction<
-  (values: TFieldValues, event: QwikSubmitEvent<HTMLFormElement>) => unknown
->;
-
-export type FormAction<TFieldValues extends FieldValues> = ActionStore<
-  any,
-  TFieldValues,
-  true
->; // TODO: Improve generics
 
 export type FormProps<
   TFieldValues extends FieldValues,
@@ -25,8 +16,8 @@ export type FormProps<
   TFieldArrayName extends FieldArrayPath<TFieldValues>
 > = Omit<QwikJSX.IntrinsicElements['form'], 'action' | 'method'> & {
   of: FormStore<TFieldValues, TFieldName, TFieldArrayName>;
-  action?: FormAction<TFieldValues>;
-  onSubmit$?: FormSubmitHandler<TFieldValues>;
+  action?: ActionStore<any, TFieldValues, true>; // TODO: Improve generics
+  onSubmit$?: SubmitHandler<TFieldValues>;
   keepResponse?: boolean;
   shouldActive?: boolean;
   shouldTouched?: boolean;

--- a/packages/qwik/src/components/Form.tsx
+++ b/packages/qwik/src/components/Form.tsx
@@ -9,16 +9,24 @@ import type {
   FieldArrayPath,
 } from '../types';
 
+export type FormSubmitHandler<TFieldValues extends FieldValues> = PropFunction<
+  (values: TFieldValues, event: QwikSubmitEvent<HTMLFormElement>) => unknown
+>;
+
+export type FormAction<TFieldValues extends FieldValues> = ActionStore<
+  any,
+  TFieldValues,
+  true
+>; // TODO: Improve generics
+
 export type FormProps<
   TFieldValues extends FieldValues,
   TFieldName extends FieldPath<TFieldValues>,
   TFieldArrayName extends FieldArrayPath<TFieldValues>
 > = Omit<QwikJSX.IntrinsicElements['form'], 'action' | 'method'> & {
   of: FormStore<TFieldValues, TFieldName, TFieldArrayName>;
-  action?: ActionStore<any, TFieldValues, true>; // TODO: Improve generics
-  onSubmit$?: PropFunction<
-    (values: TFieldValues, event: QwikSubmitEvent<HTMLFormElement>) => unknown
-  >;
+  action?: FormAction<TFieldValues>;
+  onSubmit$?: FormSubmitHandler<TFieldValues>;
   keepResponse?: boolean;
   shouldActive?: boolean;
   shouldTouched?: boolean;

--- a/packages/qwik/src/types/form.ts
+++ b/packages/qwik/src/types/form.ts
@@ -1,8 +1,20 @@
-import type { QRL, Signal } from '@builder.io/qwik';
+import type {
+  PropFunction,
+  QRL,
+  QwikSubmitEvent,
+  Signal,
+} from '@builder.io/qwik';
 import type { FieldStore, FieldValue, FieldValues } from './field';
 import type { FieldArrayStore } from './fieldArray';
 import type { FieldArrayPath, FieldPath } from './path';
 import type { DeepPartial } from './utils';
+
+/**
+ * Function type to handle the submission of the form.
+ */
+export type SubmitHandler<TFieldValues extends FieldValues> = PropFunction<
+  (values: TFieldValues, event: QwikSubmitEvent<HTMLFormElement>) => unknown
+>;
 
 /**
  * Value type of the form errors.
@@ -101,7 +113,10 @@ export type FormStore<
   response: Response;
 };
 
-export type FormValues<TFormState extends FormStore<any, any, any>> =
-  TFormState extends FormStore<infer TFieldValues, any, any>
+/**
+ * Utility type to extract the field values from the form store.
+ */
+export type FormValues<TFormStore extends FormStore<any, any, any>> =
+  TFormStore extends FormStore<infer TFieldValues, any, any>
     ? TFieldValues
     : never;

--- a/packages/qwik/src/types/form.ts
+++ b/packages/qwik/src/types/form.ts
@@ -100,3 +100,8 @@ export type FormStore<
   invalid: boolean;
   response: Response;
 };
+
+export type FormValues<TFormState extends FormStore<any, any, any>> =
+  TFormState extends FormStore<infer TFieldValues, any, any>
+    ? TFieldValues
+    : never;

--- a/packages/solid/src/components/Form.tsx
+++ b/packages/solid/src/components/Form.tsx
@@ -1,18 +1,13 @@
 import { JSX, splitProps } from 'solid-js';
 import { handleSubmit } from '../methods/handleSubmit';
-import { FieldValues, FormState, SubmitEvent } from '../types';
-
-export type FormSubmitHandler<TFieldValues extends FieldValues> = (
-  values: TFieldValues,
-  event: SubmitEvent
-) => void | Promise<void>;
+import { FieldValues, FormState, SubmitHandler } from '../types';
 
 type FormProps<TFieldValues extends FieldValues> = Omit<
   JSX.FormHTMLAttributes<HTMLFormElement>,
   'onSubmit'
 > & {
   of: FormState<TFieldValues>;
-  onSubmit: FormSubmitHandler<TFieldValues>;
+  onSubmit: SubmitHandler<TFieldValues>;
   keepResponse?: boolean;
   shouldActive?: boolean;
   shouldTouched?: boolean;

--- a/packages/solid/src/components/Form.tsx
+++ b/packages/solid/src/components/Form.tsx
@@ -2,12 +2,17 @@ import { JSX, splitProps } from 'solid-js';
 import { handleSubmit } from '../methods/handleSubmit';
 import { FieldValues, FormState, SubmitEvent } from '../types';
 
+export type FormSubmitHandler<TFieldValues extends FieldValues> = (
+  values: TFieldValues,
+  event: SubmitEvent
+) => void | Promise<void>;
+
 type FormProps<TFieldValues extends FieldValues> = Omit<
   JSX.FormHTMLAttributes<HTMLFormElement>,
   'onSubmit'
 > & {
   of: FormState<TFieldValues>;
-  onSubmit: (values: TFieldValues, event: SubmitEvent) => void | Promise<void>;
+  onSubmit: FormSubmitHandler<TFieldValues>;
   keepResponse?: boolean;
   shouldActive?: boolean;
   shouldTouched?: boolean;

--- a/packages/solid/src/methods/handleSubmit.ts
+++ b/packages/solid/src/methods/handleSubmit.ts
@@ -1,5 +1,5 @@
 import { batch } from 'solid-js';
-import { FieldValues, FormState, SubmitEvent } from '../types';
+import { FieldValues, FormState, SubmitEvent, SubmitHandler } from '../types';
 import { getValues } from './getValues';
 import { validate } from './validate';
 
@@ -21,10 +21,7 @@ type SubmitOptions = Partial<{
  */
 export function handleSubmit<TFieldValues extends FieldValues>(
   form: FormState<TFieldValues>,
-  submitAction: (
-    values: TFieldValues,
-    event: SubmitEvent
-  ) => void | Promise<void>,
+  submitAction: SubmitHandler<TFieldValues>,
   options: SubmitOptions = {}
 ): (event: SubmitEvent) => Promise<void> {
   return async (event: SubmitEvent) => {

--- a/packages/solid/src/types/form.ts
+++ b/packages/solid/src/types/form.ts
@@ -82,3 +82,9 @@ export type FormState<TFieldValues extends FieldValues> = {
   invalid: boolean;
   response: Response;
 };
+
+/* 
+  Extracts the field values from the form state.
+*/
+export type FormValues<TFormState extends FormState<any>> =
+  TFormState extends FormState<infer TFieldValues> ? TFieldValues : never;

--- a/packages/solid/src/types/form.ts
+++ b/packages/solid/src/types/form.ts
@@ -15,6 +15,14 @@ export type SubmitEvent = Event & {
 };
 
 /**
+ * Function type to handle the submission of the form.
+ */
+export type SubmitHandler<TFieldValues extends FieldValues> = (
+  values: TFieldValues,
+  event: SubmitEvent
+) => void | Promise<void>;
+
+/**
  * Value type of the response status.
  */
 type ResponseStatus = 'info' | 'error' | 'success';
@@ -83,8 +91,8 @@ export type FormState<TFieldValues extends FieldValues> = {
   response: Response;
 };
 
-/* 
-  Extracts the field values from the form state.
-*/
+/**
+ * Utility type to extract the field values from the form state.
+ */
 export type FormValues<TFormState extends FormState<any>> =
   TFormState extends FormState<infer TFieldValues> ? TFieldValues : never;


### PR DESCRIPTION
- Adds FormValues extraction type

Allows to get the types of values directly from the form and not having to generate types from the validation schema

```ts
const todoForm = createForm() // const [todoForm] = useForm()

type FormValues = FormValues<typeof todoForm>
```

-  Adds onSubmit and action handler types like on React Hook Forms: https://react-hook-form.com/ts/#SubmitHandler

Useful for typing handlers like so:
```ts
const handleSubmit: FormSubmitHandler<FormValues> = () => {}
```

Let me know if you have any feedback :smile: 