### PR TITLE
Rename autoFocus and noValidate props to match HTML equivalent

### DIFF
--- a/packages/solid/src/components/Field.tsx
+++ b/packages/solid/src/components/Field.tsx
@@ -50,7 +50,7 @@ export type FieldElementProps<
   TFieldName extends FieldPath<TFieldValues>
 > = {
   get name(): TFieldName;
-  get autoFocus(): boolean;
+  get autofocus(): boolean;
   ref: (element: FieldElement) => void;
   onInput: JSX.EventHandler<FieldElement, InputEvent>;
   onChange: JSX.EventHandler<FieldElement, Event>;
@@ -128,7 +128,7 @@ export function Field<
           get name() {
             return props.name;
           },
-          get autoFocus() {
+          get autofocus() {
             return !!getField().error.get();
           },
           ref(element) {

--- a/packages/solid/src/components/Form.tsx
+++ b/packages/solid/src/components/Form.tsx
@@ -66,7 +66,7 @@ export function Form<
 
   return (
     <form
-      noValidate
+      novalidate
       {...other}
       ref={props.of.internal.element.set}
       onSubmit={async (event: SubmitEvent) => {

--- a/website/src/routes/(layout)/[framework]/api/FieldElementProps.mdx
+++ b/website/src/routes/(layout)/[framework]/api/FieldElementProps.mdx
@@ -21,7 +21,7 @@ Type that defines the element properties of a field.
 
 - `FieldElementProps` <Property type="object" />
   - `name` <Property type="string" />
-  - `autoFocus` <Property type="boolean" />
+  - `autofocus` <Property type="boolean" />
   - `ref` <Property {...properties.solid.ref} />
   - `onInput` <Property {...properties.solid.onInput} />
   - `onChange` <Property {...properties.solid.onChange} />


### PR DESCRIPTION
More information in [#92](https://github.com/fabian-hiller/modular-forms/issues/92#issuecomment-1600780399)