### PR TITLE
Fixed Qwik Code in Example Input Components

### DIFF
--- a/website/src/routes/(layout)/[framework]/guides/input-components.mdx
+++ b/website/src/routes/(layout)/[framework]/guides/input-components.mdx
@@ -337,7 +337,7 @@ export const TextInput = component$(
           aria-invalid={!!error}
           aria-errormessage={`${name}-error`}
         />
-        {props.error && <div id={`${name}-error`}>{error}</div>}
+        {error && <div id={`${name}-error`}>{error}</div>}
       </div>
     );
   }
@@ -521,7 +521,7 @@ export const TextInput = component$(
           aria-invalid={!!error}
           aria-errormessage={`${name}-error`}
         />
-        {props.error && <div id={`${name}-error`}>{error}</div>}
+        {error && <div id={`${name}-error`}>{error}</div>}
       </div>
     );
   }


### PR DESCRIPTION
There was a error in qwik code, you have split the props so, props.error is no longer available