### PR TITLE
Fix typo in validate.mdx

### DIFF
--- a/website/src/routes/(layout)/[framework]/api/validate.mdx
+++ b/website/src/routes/(layout)/[framework]/api/validate.mdx
@@ -14,7 +14,7 @@ Validates the entire form, several fields and field arrays or a single field or 
 // Validate the entire form
 validate(form, options);
 
-// Validate a singel field or field array
+// Validate a single field or field array
 validate(form, name, options);
 
 // Validate several fields and field arrays


### PR DESCRIPTION
Changing 'singel' to 'single'.

Thanks for this nice library :heart: 