### PR TITLE
Make (re)validateOn overridable per field

### DIFF
--- a/packages/preact/CHANGELOG.md
+++ b/packages/preact/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add support for async validation with Zod (issue #233)
+- Add `validateOn` and `revalidateOn` option to `Field` and `FieldArray` component (pull request #247)
 
 ## v0.9.1 (June 27, 2024)
 

--- a/packages/preact/src/components/Field.tsx
+++ b/packages/preact/src/components/Field.tsx
@@ -17,6 +17,7 @@ import type {
   ResponseData,
   TransformField,
   ValidateField,
+  ValidationMode,
 } from '../types';
 import {
   getElementInput,
@@ -71,6 +72,8 @@ export type FieldProps<
   validate?: Maybe<
     MaybeArray<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<TransformField<FieldPathValue<TFieldValues, TFieldName>>>
   >;

--- a/packages/preact/src/components/FieldArray.tsx
+++ b/packages/preact/src/components/FieldArray.tsx
@@ -11,6 +11,7 @@ import type {
   MaybeArray,
   ResponseData,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { initializeFieldArrayStore } from '../utils';
 
@@ -43,6 +44,8 @@ export type FieldArrayProps<
     store: FieldArrayStore<TFieldValues, TFieldArrayName>
   ) => ComponentChild;
   validate?: Maybe<MaybeArray<ValidateFieldArray<number[]>>>;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   keepActive?: Maybe<boolean>;
   keepState?: Maybe<boolean>;
 };

--- a/packages/preact/src/hooks/useLifecycle.ts
+++ b/packages/preact/src/hooks/useLifecycle.ts
@@ -15,6 +15,7 @@ import type {
   TransformField,
   ValidateField,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { getUniqueId, updateFormState } from '../utils';
 
@@ -33,6 +34,8 @@ type LifecycleProps<
     | MaybeArray<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>
     | MaybeArray<ValidateFieldArray<number[]>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<TransformField<FieldPathValue<TFieldValues, TFieldName>>>
   >;
@@ -56,6 +59,8 @@ export function useLifecycle({
   name,
   store,
   validate,
+  validateOn,
+  revalidateOn,
   transform,
   keepActive = false,
   keepState = true,
@@ -68,6 +73,10 @@ export function useLifecycle({
         : [validate]
       : [];
 
+    // Set validation mode overrides
+    store.validateOn = validateOn;
+    store.revalidateOn = revalidateOn;
+
     // Add transformation functions
     if ('transform' in store) {
       store.transform = transform
@@ -76,7 +85,7 @@ export function useLifecycle({
           : [transform]
         : [];
     }
-  }, [store, transform, validate]);
+  }, [store, transform, validate, validateOn, revalidateOn]);
 
   useEffect(() => {
     // Create unique consumer ID

--- a/packages/preact/src/types/field.ts
+++ b/packages/preact/src/types/field.ts
@@ -1,6 +1,7 @@
 import type { Signal } from '@preact/signals';
 import type { FieldPath, FieldPathValue } from './path';
 import type { MaybeValue, MaybePromise, Maybe } from './utils';
+import type { ValidationMode } from './form';
 
 /**
  * Value type of the field value.
@@ -89,6 +90,8 @@ export type InternalFieldStore<
 
   // Other
   validate: ValidateField<FieldPathValue<TFieldValues, TFieldName>>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   transform: TransformField<FieldPathValue<TFieldValues, TFieldName>>[];
   consumers: Set<number>;
 };

--- a/packages/preact/src/types/fieldArray.ts
+++ b/packages/preact/src/types/fieldArray.ts
@@ -1,5 +1,6 @@
 import type { Signal } from '@preact/signals';
-import type { MaybePromise } from './utils';
+import type { Maybe, MaybePromise } from './utils';
+import type { ValidationMode } from './form';
 
 /**
  * Function type to validate a field array.
@@ -28,6 +29,8 @@ export type InternalFieldArrayStore = {
 
   // Other
   validate: ValidateFieldArray<number[]>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   consumers: Set<number>;
 };
 

--- a/packages/preact/src/utils/initializeFieldArrayStore.ts
+++ b/packages/preact/src/utils/initializeFieldArrayStore.ts
@@ -47,6 +47,8 @@ export function initializeFieldArrayStore<
 
       // Other
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       consumers: new Set(),
     };
 

--- a/packages/preact/src/utils/initializeFieldStore.ts
+++ b/packages/preact/src/utils/initializeFieldStore.ts
@@ -55,6 +55,8 @@ export function initializeFieldStore(
 
       // Other
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       transform: [],
       consumers: new Set(),
     };

--- a/packages/preact/src/utils/validateIfRequired.ts
+++ b/packages/preact/src/utils/validateIfRequired.ts
@@ -40,15 +40,18 @@ export function validateIfRequired<
   name: TFieldName | TFieldArrayName,
   { on: modes, shouldFocus = false }: ValidateOptions
 ): void {
+  const validateOn = fieldOrFieldArray.validateOn ?? form.internal.validateOn;
+  const revalidateOn =
+    fieldOrFieldArray.revalidateOn ?? form.internal.revalidateOn;
   if (
     (modes as string[]).includes(
       (
-        form.internal.validateOn === 'submit'
+        validateOn === 'submit'
           ? form.submitted.peek()
           : fieldOrFieldArray.error.peek()
       )
-        ? form.internal.revalidateOn
-        : form.internal.validateOn
+        ? revalidateOn
+        : validateOn
     )
   ) {
     validate(form, name, { shouldFocus });

--- a/packages/qwik/CHANGELOG.md
+++ b/packages/qwik/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add support for async validation with Zod (issue #233)
+- Add `validateOn` and `revalidateOn` option to `Field` and `FieldArray` component (pull request #247)
 
 ## v0.26.1 (June 27, 2024)
 

--- a/packages/qwik/src/components/Field.tsx
+++ b/packages/qwik/src/components/Field.tsx
@@ -18,6 +18,7 @@ import type {
   ResponseData,
   TransformField,
   ValidateField,
+  ValidationMode,
 } from '../types';
 import { Lifecycle } from './Lifecycle';
 
@@ -54,6 +55,8 @@ export type FieldProps<
   validate?: Maybe<
     MaybeArray<QRL<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<QRL<TransformField<FieldPathValue<TFieldValues, TFieldName>>>>
   >;

--- a/packages/qwik/src/components/FieldArray.tsx
+++ b/packages/qwik/src/components/FieldArray.tsx
@@ -9,6 +9,7 @@ import type {
   MaybeArray,
   ResponseData,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { Lifecycle } from './Lifecycle';
 
@@ -26,6 +27,8 @@ export type FieldArrayProps<
     store: FieldArrayStore<TFieldValues, TFieldArrayName>
   ) => JSXOutput;
   validate?: Maybe<MaybeArray<QRL<ValidateFieldArray<number[]>>>>;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   keepActive?: Maybe<boolean>;
   keepState?: Maybe<boolean>;
 };

--- a/packages/qwik/src/components/Lifecycle.tsx
+++ b/packages/qwik/src/components/Lifecycle.tsx
@@ -22,6 +22,7 @@ import type {
   TransformField,
   ValidateField,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { getUniqueId, updateFormState } from '../utils';
 
@@ -43,6 +44,8 @@ type LifecycleProps<
     | MaybeArray<QRL<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>>
     | MaybeArray<QRL<ValidateFieldArray<number[]>>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<QRL<TransformField<FieldPathValue<TFieldValues, TFieldName>>>>
   >;
@@ -77,6 +80,8 @@ export function Lifecycle(
       of: form,
       store,
       validate,
+      validateOn,
+      revalidateOn,
       transform,
       keepActive = false,
       keepState = true,
@@ -95,6 +100,10 @@ export function Lifecycle(
             ? validate
             : [validate]
           : [];
+
+        // Set validation mode overrides
+        store.internal.validateOn = validateOn;
+        store.internal.revalidateOn = revalidateOn;
 
         // Add transformation functions
         if ('value' in store) {

--- a/packages/qwik/src/types/field.ts
+++ b/packages/qwik/src/types/field.ts
@@ -1,6 +1,7 @@
 import type { NoSerialize, QRL } from '@builder.io/qwik';
 import type { FieldPath, FieldPathValue } from './path';
 import type { Maybe, MaybePromise, MaybeValue } from './utils';
+import type { ValidationMode } from './form';
 
 /**
  * Value type of the field value.
@@ -87,6 +88,8 @@ export type InternalFieldStore<
   initialValue: Maybe<FieldPathValue<TFieldValues, TFieldName>>;
   startValue: Maybe<FieldPathValue<TFieldValues, TFieldName>>;
   validate: QRL<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   transform: QRL<TransformField<FieldPathValue<TFieldValues, TFieldName>>>[];
   elements: FieldElement[];
   consumers: number[];

--- a/packages/qwik/src/types/fieldArray.ts
+++ b/packages/qwik/src/types/fieldArray.ts
@@ -1,7 +1,8 @@
 import type { QRL } from '@builder.io/qwik';
 import type { FieldValues } from './field';
 import type { FieldArrayPath } from './path';
-import type { MaybePromise } from './utils';
+import type { Maybe, MaybePromise } from './utils';
+import type { ValidationMode } from './form';
 
 /**
  * Function type to validate a field array.
@@ -22,6 +23,8 @@ export type InternalFieldArrayStore = {
   initialItems: number[];
   startItems: number[];
   validate: QRL<ValidateFieldArray<number[]>>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   consumers: number[];
 };
 

--- a/packages/qwik/src/utils/getInitialFieldArrayStore.ts
+++ b/packages/qwik/src/utils/getInitialFieldArrayStore.ts
@@ -34,6 +34,8 @@ export function getInitialFieldArrayStore<
       initialItems: [...initialItems],
       startItems: [...initialItems],
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       consumers: [],
     },
     name,

--- a/packages/qwik/src/utils/getInitialFieldStore.ts
+++ b/packages/qwik/src/utils/getInitialFieldStore.ts
@@ -51,6 +51,8 @@ export function getInitialFieldStore<
       initialValue,
       startValue: initialValue,
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       transform: [],
       elements: [],
       consumers: [],

--- a/packages/qwik/src/utils/validateIfRequired.ts
+++ b/packages/qwik/src/utils/validateIfRequired.ts
@@ -40,15 +40,15 @@ export function validateIfRequired<
   name: TFieldName | TFieldArrayName,
   { on: modes, shouldFocus = false }: ValidateOptions
 ): void {
+  const validateOn =
+    fieldOrFieldArray.internal.validateOn ?? form.internal.validateOn;
+  const revalidateOn =
+    fieldOrFieldArray.internal.revalidateOn ?? form.internal.revalidateOn;
   if (
     (modes as string[]).includes(
-      (
-        form.internal.validateOn === 'submit'
-          ? form.submitted
-          : fieldOrFieldArray.error
-      )
-        ? form.internal.revalidateOn
-        : form.internal.validateOn
+      (validateOn === 'submit' ? form.submitted : fieldOrFieldArray.error)
+        ? revalidateOn
+        : validateOn
     )
   ) {
     validate(form, name, { shouldFocus });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add support for async validation with Zod (issue #233)
+- Add `validateOn` and `revalidateOn` option to `Field` and `FieldArray` component (pull request #247)
 
 ## v0.8.1 (June 27, 2024)
 

--- a/packages/react/src/components/Field.tsx
+++ b/packages/react/src/components/Field.tsx
@@ -21,6 +21,7 @@ import type {
   ResponseData,
   TransformField,
   ValidateField,
+  ValidationMode,
 } from '../types';
 import {
   getElementInput,
@@ -74,6 +75,8 @@ export type FieldProps<
   validate?: Maybe<
     MaybeArray<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<TransformField<FieldPathValue<TFieldValues, TFieldName>>>
   >;

--- a/packages/react/src/components/FieldArray.tsx
+++ b/packages/react/src/components/FieldArray.tsx
@@ -9,6 +9,7 @@ import type {
   MaybeArray,
   ResponseData,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { initializeFieldArrayStore } from '../utils';
 
@@ -41,6 +42,8 @@ export type FieldArrayProps<
     store: FieldArrayStore<TFieldValues, TFieldArrayName>
   ) => ReactNode;
   validate?: Maybe<MaybeArray<ValidateFieldArray<number[]>>>;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   keepActive?: Maybe<boolean>;
   keepState?: Maybe<boolean>;
 };

--- a/packages/react/src/hooks/useLifecycle.ts
+++ b/packages/react/src/hooks/useLifecycle.ts
@@ -15,6 +15,7 @@ import type {
   TransformField,
   ValidateField,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { getUniqueId, updateFormState } from '../utils';
 
@@ -33,6 +34,8 @@ type LifecycleProps<
     | MaybeArray<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>
     | MaybeArray<ValidateFieldArray<number[]>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<TransformField<FieldPathValue<TFieldValues, TFieldName>>>
   >;
@@ -56,6 +59,8 @@ export function useLifecycle({
   name,
   store,
   validate,
+  validateOn,
+  revalidateOn,
   transform,
   keepActive = false,
   keepState = true,
@@ -68,6 +73,10 @@ export function useLifecycle({
         : [validate]
       : [];
 
+    // Set validation mode overrides
+    store.validateOn = validateOn;
+    store.revalidateOn = revalidateOn;
+
     // Add transformation functions
     if ('transform' in store) {
       store.transform = transform
@@ -76,7 +85,7 @@ export function useLifecycle({
           : [transform]
         : [];
     }
-  }, [store, transform, validate]);
+  }, [store, transform, validate, validateOn, revalidateOn]);
 
   useEffect(() => {
     // Create unique consumer ID

--- a/packages/react/src/types/field.ts
+++ b/packages/react/src/types/field.ts
@@ -2,6 +2,7 @@ import type { Signal } from '@preact/signals-react';
 import type { SyntheticEvent } from 'react';
 import type { FieldPath, FieldPathValue } from './path';
 import type { MaybeValue, MaybePromise, Maybe } from './utils';
+import type { ValidationMode } from './form';
 
 /**
  * Value type of the field value.
@@ -90,6 +91,8 @@ export type InternalFieldStore<
 
   // Other
   validate: ValidateField<FieldPathValue<TFieldValues, TFieldName>>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   transform: TransformField<FieldPathValue<TFieldValues, TFieldName>>[];
   consumers: Set<number>;
 };

--- a/packages/react/src/types/fieldArray.ts
+++ b/packages/react/src/types/fieldArray.ts
@@ -1,5 +1,6 @@
 import type { Signal } from '@preact/signals-react';
-import type { MaybePromise } from './utils';
+import type { Maybe, MaybePromise } from './utils';
+import type { ValidationMode } from './form';
 
 /**
  * Function type to validate a field array.
@@ -28,6 +29,8 @@ export type InternalFieldArrayStore = {
 
   // Other
   validate: ValidateFieldArray<number[]>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   consumers: Set<number>;
 };
 

--- a/packages/react/src/utils/initializeFieldArrayStore.ts
+++ b/packages/react/src/utils/initializeFieldArrayStore.ts
@@ -47,6 +47,8 @@ export function initializeFieldArrayStore<
 
       // Other
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       consumers: new Set(),
     };
 

--- a/packages/react/src/utils/initializeFieldStore.ts
+++ b/packages/react/src/utils/initializeFieldStore.ts
@@ -55,6 +55,8 @@ export function initializeFieldStore(
 
       // Other
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       transform: [],
       consumers: new Set(),
     };

--- a/packages/react/src/utils/validateIfRequired.ts
+++ b/packages/react/src/utils/validateIfRequired.ts
@@ -40,15 +40,18 @@ export function validateIfRequired<
   name: TFieldName | TFieldArrayName,
   { on: modes, shouldFocus = false }: ValidateOptions
 ): void {
+  const validateOn = fieldOrFieldArray.validateOn ?? form.internal.validateOn;
+  const revalidateOn =
+    fieldOrFieldArray.revalidateOn ?? form.internal.revalidateOn;
   if (
     (modes as string[]).includes(
       (
-        form.internal.validateOn === 'submit'
+        validateOn === 'submit'
           ? form.submitted.peek()
           : fieldOrFieldArray.error.peek()
       )
-        ? form.internal.revalidateOn
-        : form.internal.validateOn
+        ? revalidateOn
+        : validateOn
     )
   ) {
     validate(form, name, { shouldFocus });

--- a/packages/solid/CHANGELOG.md
+++ b/packages/solid/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Add support for async validation with Zod (issue #233)
+- Add `validateOn` and `revalidateOn` option to `Field` and `FieldArray` component (pull request #247)
 
 ## v0.22.1 (June 27, 2024)
 

--- a/packages/solid/src/components/Field.tsx
+++ b/packages/solid/src/components/Field.tsx
@@ -20,6 +20,7 @@ import type {
   ResponseData,
   TransformField,
   ValidateField,
+  ValidationMode,
 } from '../types';
 import {
   getElementInput,
@@ -75,6 +76,8 @@ export type FieldProps<
   validate?: Maybe<
     MaybeArray<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<TransformField<FieldPathValue<TFieldValues, TFieldName>>>
   >;

--- a/packages/solid/src/components/FieldArray.tsx
+++ b/packages/solid/src/components/FieldArray.tsx
@@ -8,6 +8,7 @@ import type {
   MaybeArray,
   ResponseData,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { initializeFieldArrayStore } from '../utils';
 
@@ -40,6 +41,8 @@ export type FieldArrayProps<
     store: FieldArrayStore<TFieldValues, TFieldArrayName>
   ) => JSX.Element;
   validate?: Maybe<MaybeArray<ValidateFieldArray<number[]>>>;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   keepActive?: Maybe<boolean>;
   keepState?: Maybe<boolean>;
 };

--- a/packages/solid/src/primitives/createLifecycle.ts
+++ b/packages/solid/src/primitives/createLifecycle.ts
@@ -14,6 +14,7 @@ import type {
   TransformField,
   ValidateField,
   ValidateFieldArray,
+  ValidationMode,
 } from '../types';
 import { getUniqueId, updateFormState } from '../utils';
 
@@ -34,6 +35,8 @@ type LifecycleProps<
     | MaybeArray<ValidateField<FieldPathValue<TFieldValues, TFieldName>>>
     | MaybeArray<ValidateFieldArray<number[]>>
   >;
+  validateOn?: Maybe<ValidationMode>;
+  revalidateOn?: Maybe<ValidationMode>;
   transform?: Maybe<
     MaybeArray<TransformField<FieldPathValue<TFieldValues, TFieldName>>>
   >;
@@ -57,6 +60,8 @@ export function createLifecycle({
   name,
   getStore,
   validate,
+  validateOn,
+  revalidateOn,
   transform,
   keepActive = false,
   keepState = true,
@@ -71,6 +76,10 @@ export function createLifecycle({
         ? validate
         : [validate]
       : [];
+
+    // Set validation mode overrides
+    store.validateOn = validateOn;
+    store.revalidateOn = revalidateOn;
 
     // Add transformation functions
     if ('transform' in store) {

--- a/packages/solid/src/types/field.ts
+++ b/packages/solid/src/types/field.ts
@@ -1,4 +1,5 @@
 import type { Signal } from '../primitives';
+import type { ValidationMode } from './form';
 import type { FieldPath, FieldPathValue } from './path';
 import type { MaybeValue, MaybePromise, Maybe } from './utils';
 
@@ -89,6 +90,8 @@ export type InternalFieldStore<
 
   // Other
   validate: ValidateField<FieldPathValue<TFieldValues, TFieldName>>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   transform: TransformField<FieldPathValue<TFieldValues, TFieldName>>[];
   consumers: Set<number>;
 };

--- a/packages/solid/src/types/fieldArray.ts
+++ b/packages/solid/src/types/fieldArray.ts
@@ -1,5 +1,6 @@
 import type { Signal } from '../primitives';
-import type { MaybePromise } from './utils';
+import type { ValidationMode } from './form';
+import type { Maybe, MaybePromise } from './utils';
 
 /**
  * Function type to validate a field array.
@@ -28,6 +29,8 @@ export type InternalFieldArrayStore = {
 
   // Other
   validate: ValidateFieldArray<number[]>[];
+  validateOn: Maybe<ValidationMode>;
+  revalidateOn: Maybe<ValidationMode>;
   consumers: Set<number>;
 };
 

--- a/packages/solid/src/utils/initializeFieldArrayStore.ts
+++ b/packages/solid/src/utils/initializeFieldArrayStore.ts
@@ -56,6 +56,8 @@ export function initializeFieldArrayStore<
 
       // Other
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       consumers: new Set(),
     };
 

--- a/packages/solid/src/utils/initializeFieldStore.ts
+++ b/packages/solid/src/utils/initializeFieldStore.ts
@@ -66,6 +66,8 @@ export function initializeFieldStore(
 
       // Other
       validate: [],
+      validateOn: undefined,
+      revalidateOn: undefined,
       transform: [],
       consumers: new Set(),
     };

--- a/packages/solid/src/utils/validateIfRequired.ts
+++ b/packages/solid/src/utils/validateIfRequired.ts
@@ -42,15 +42,18 @@ export function validateIfRequired<
   { on: modes, shouldFocus = false }: ValidateOptions
 ): void {
   untrack(() => {
+    const validateOn = fieldOrFieldArray.validateOn ?? form.internal.validateOn;
+    const revalidateOn =
+      fieldOrFieldArray.revalidateOn ?? form.internal.revalidateOn;
     if (
       (modes as string[]).includes(
         (
-          form.internal.validateOn === 'submit'
+          validateOn === 'submit'
             ? form.internal.submitted.get()
             : fieldOrFieldArray.error.get()
         )
-          ? form.internal.revalidateOn
-          : form.internal.validateOn
+          ? revalidateOn
+          : validateOn
       )
     ) {
       validate(form, name, { shouldFocus });

--- a/website/src/routes/(layout)/[framework]/api/Field.mdx
+++ b/website/src/routes/(layout)/[framework]/api/Field.mdx
@@ -16,6 +16,8 @@ Headless form field that provides reactive properties and state.
   name={…}
   type={…}
   validate={…}
+  validateOn={…}
+  revalidateOn={…}
   transform={…}
   keepActive={…}
   keepState={…}
@@ -30,6 +32,8 @@ Headless form field that provides reactive properties and state.
 - `name` <Property type="string" />
 - `type` <Property {...properties.type} />
 - `validate` <Property {...properties[isQwik() ? 'qwik' : 'solidPreactOrReact'].validate} />
+- `validateOn` <Property {...properties[isReact() ? 'react' : 'solidQwikOrReact'].validateOn} />
+- `revalidateOn` <Property {...properties[isReact() ? 'react' : 'solidQwikOrReact'].revalidateOn} />
 - `transform` <Property {...properties[isQwik() ? 'qwik' : 'solidPreactOrReact'].transform} />
 - `keepActive` <Property {...properties.keepActive} />
 - `keepState` <Property {...properties.keepState} />
@@ -150,6 +154,28 @@ export const properties = {
       },
     },
   },
+  solidQwikOrReact: {
+    validateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'input' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'submit' },
+    },
+    revalidateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'input' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'input' },
+    },
+  },
   qwik: {
     validate: {
       type: {
@@ -256,6 +282,24 @@ export const properties = {
         ],
         return: { type: 'custom', name: 'ReactNode' },
       },
+    },
+    validateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'submit' },
+    },
+    revalidateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'change' },
     },
   },
 };

--- a/website/src/routes/(layout)/[framework]/api/FieldArray.mdx
+++ b/website/src/routes/(layout)/[framework]/api/FieldArray.mdx
@@ -21,6 +21,8 @@ Headless field array that provides reactive properties and state.
 - `of` <Property {...properties.of} />
 - `name` <Property type="string" />
 - `validate` <Property {...properties[isQwik() ? 'qwik' : 'solidPreactOrReact'].validate} />
+- `validateOn` <Property {...properties[isReact() ? 'react' : 'solidQwikOrReact'].validateOn} />
+- `revalidateOn` <Property {...properties[isReact() ? 'react' : 'solidQwikOrReact'].revalidateOn} />
 - `keepActive` <Property {...properties.keepActive} />
 - `keepState` <Property {...properties.keepState} />
 - `children` <Property {...properties[isPreact() ? 'preact' : isReact() ? 'react' : 'solidOrQwik'].children} />
@@ -90,6 +92,28 @@ export const properties = {
       },
     },
   },
+  solidQwikOrReact: {
+    validateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'input' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'submit' },
+    },
+    revalidateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'input' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'input' },
+    },
+  },
   qwik: {
     validate: {
       type: {
@@ -153,6 +177,24 @@ export const properties = {
         ],
         return: { type: 'custom', name: 'ReactNode' },
       },
+    },
+    validateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'submit' },
+    },
+    revalidateOn: {
+      type: [
+        { type: 'string', value: 'touched' },
+        { type: 'string', value: 'change' },
+        { type: 'string', value: 'blur' },
+        { type: 'string', value: 'submit' },
+      ],
+      defaultValue: { type: 'string', value: 'change' },
     },
   },
 };


### PR DESCRIPTION
Previously, `(re)validateOn` could only be set at the top of the form. However, in some cases, it'd be desirable to override this behavior (mostly because some fields already fulfill the validation from the start), so I made one.
I've thought about the implementation of `setValues` but left it as-is for now.

~~If the Solid implementation gets approved, I'll also implement it for others.~~ Done!