### PR TITLE
Fix Qwik dependency version specifier

### DIFF
--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -65,7 +65,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@builder.io/qwik": "^1.9.0 | ^2.0.0",
-    "@builder.io/qwik-city": "^1.9.0 | ^2.0.0"
+    "@builder.io/qwik": "^1.9.0 || ^2.0.0",
+    "@builder.io/qwik-city": "^1.9.0 || ^2.0.0"
   }
 }


### PR DESCRIPTION
These "or" clauses should have a `||` instead of just `|`.