### PR TITLE
fix accessing array field type by path

### DIFF
--- a/packages/preact/src/types/path.ts
+++ b/packages/preact/src/types/path.ts
@@ -38,13 +38,17 @@ type PathValue<TValue, TPath> = TPath extends `${infer TKey1}.${infer TKey2}`
       ? PathValue<TValue[TKey1], TKey2>
       : never
     : TKey1 extends `${ArrayKey}`
-    ? TValue extends Array<infer TChild>
-      ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+      ? TValue extends Array<infer TChild>
+        ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+        : never
       : never
-    : never
   : TPath extends keyof TValue
-  ? TValue[TPath]
-  : never;
+    ? TValue[TPath]
+    : TPath extends `${ArrayKey}`
+      ? TValue extends Array<infer TChild>
+        ? TChild
+        : never
+      : never;
 
 /**
  * See {@link PathValue}

--- a/packages/qwik/src/types/path.ts
+++ b/packages/qwik/src/types/path.ts
@@ -38,13 +38,17 @@ type PathValue<TValue, TPath> = TPath extends `${infer TKey1}.${infer TKey2}`
       ? PathValue<TValue[TKey1], TKey2>
       : never
     : TKey1 extends `${ArrayKey}`
-    ? TValue extends Array<infer TChild>
-      ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+      ? TValue extends Array<infer TChild>
+        ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+        : never
       : never
-    : never
   : TPath extends keyof TValue
-  ? TValue[TPath]
-  : never;
+    ? TValue[TPath]
+    : TPath extends `${ArrayKey}`
+      ? TValue extends Array<infer TChild>
+        ? TChild
+        : never
+      : never;
 
 /**
  * See {@link PathValue}

--- a/packages/react/src/types/path.ts
+++ b/packages/react/src/types/path.ts
@@ -38,13 +38,17 @@ type PathValue<TValue, TPath> = TPath extends `${infer TKey1}.${infer TKey2}`
       ? PathValue<TValue[TKey1], TKey2>
       : never
     : TKey1 extends `${ArrayKey}`
-    ? TValue extends Array<infer TChild>
-      ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+      ? TValue extends Array<infer TChild>
+        ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+        : never
       : never
-    : never
   : TPath extends keyof TValue
-  ? TValue[TPath]
-  : never;
+    ? TValue[TPath]
+    : TPath extends `${ArrayKey}`
+      ? TValue extends Array<infer TChild>
+        ? TChild
+        : never
+      : never;
 
 /**
  * See {@link PathValue}

--- a/packages/solid/src/types/path.ts
+++ b/packages/solid/src/types/path.ts
@@ -38,13 +38,17 @@ type PathValue<TValue, TPath> = TPath extends `${infer TKey1}.${infer TKey2}`
       ? PathValue<TValue[TKey1], TKey2>
       : never
     : TKey1 extends `${ArrayKey}`
-    ? TValue extends Array<infer TChild>
-      ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+      ? TValue extends Array<infer TChild>
+        ? PathValue<TChild, TKey2 & (ValuePaths<TChild> | ArrayPaths<TChild>)>
+        : never
       : never
-    : never
   : TPath extends keyof TValue
-  ? TValue[TPath]
-  : never;
+    ? TValue[TPath]
+    : TPath extends `${ArrayKey}`
+      ? TValue extends Array<infer TChild>
+        ? TChild
+        : never
+      : never;
 
 /**
  * See {@link PathValue}


### PR DESCRIPTION
The Field component seems to show type errors when used with an Array field that is not an object - for example:

```
const TestComponent = () => {
  const [form, { Form, Field }] = createForm<{ values: number[] }>({
    initialValues: { values: [1, 2, 3] },
  });

  return (
    <Form onSubmit={() => {}}>
      <Field name="values.0" type="number">
        {(field, props) => (
          <input type="number" {...props} value={field.value} />
        )}
      </Field>
    </Form>
  );
};
```

Will show the errors 
- on the "type" prop - "Type 'string' is not assignable to type 'undefined'."
- the type of "field.value" will be "undefined"

This PR updates the PathValue helper to allow looking up a value by array index