### PR TITLE
fix: align peerDependencies and devDependencies for signals-react

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,7 +65,7 @@
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "@preact/signals-react": "^1.0.0",
+    "@preact/signals-react": "^2.2.0",
     "react": "^18.0.0"
   }
 }


### PR DESCRIPTION
I also hit the ERESOLVE error in https://github.com/fabian-hiller/modular-forms/issues/282

It looks like signals-react ^2.2.0 is already a devDependency, it is just that in the peerDependencies it is set to ^1.0.0 which causes the resolution error. Bringing the peer dependency up to the version that is already in devDependencies (or alternatively at least || allowing it) seems a way forward.